### PR TITLE
Use vararg to pass arguments to command

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -19,4 +19,5 @@ ctr.S = minetest.get_translator(ctr.mod.name)
 -- Load the scripts
 dofile(ctr.mod.path .. "/src/utilities.lua")
 dofile(ctr.mod.path .. "/src/os/api/cli.lua")
+dofile(ctr.mod.path .. "/src/os/bin/echo.lua")
 dofile(ctr.mod.path .. "/src/nodes/computer.lua")

--- a/src/nodes/computer.lua
+++ b/src/nodes/computer.lua
@@ -59,14 +59,14 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
             end
 
             -- Execute the command
-            for name, def in pairs(ctr.registered_commands) do
-                if name == command then
-                    local stdin, stdout, stderr, exit_code = def.func(player, ctr.split(command, " "))
-                    if stderr ~= "" then
-                        terminal_text = terminal_text .. stderr
-                    elseif stdout ~= "" then
-                        terminal_text = terminal_text .. stdout
-                    end
+            local args = string.split(command, "%s+", false, -1, true)
+            local def = ctr.registered_commands[args[1]]
+            if def ~= nil then
+                local stdin, stdout, stderr, exit_code = def.func(player, #args-1, unpack(args, 2))
+                if stderr ~= "" then
+                    terminal_text = terminal_text .. stderr
+                elseif stdout ~= "" then
+                    terminal_text = terminal_text .. stdout
                 end
             end
 

--- a/src/os/bin/echo.lua
+++ b/src/os/bin/echo.lua
@@ -1,0 +1,5 @@
+ctr.register_command("echo", {
+    func = function(player, argc, ...)
+        return "", table.concat({...}, " ") .. "\n", "", 0
+    end,
+})


### PR DESCRIPTION
There are some other minor changes:
* Multiple spaces have the same effect as a single space (i.e. `echo      foo     bar` - with multiple spaces - is treated as `echo foo bar`)
* The number of arguments is also passed to the command
* Command lookup has been changed to a table indexing operation.
* The `echo` command is added for testing, but I don't mind removing it if it is not desired.